### PR TITLE
[WIP]ユーザー新規登録時のバリデーション機能追加

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -5,10 +5,54 @@ $(function() {
   });
 
   $("#button__step1").on("click", function() {
-    $("#step1").hide();
-    $("#step3").hide();
-    $("#step2").show();
-    scrollTo(0,0);
+    let error;
+    let value__nickname = $("input#step1__nickname").val();
+    let value__email = $("input#step1__email").val();
+    let value__password = $("input#step1__password").val();
+    let value__firstname_kanji = $("input#step1__firstname_kanji").val();
+    let value__lastname_kanji = $("input#step1__lastname_kanji").val();
+    let value__firstname_katakana = $("input#step1__firstname_katakana").val();
+    let value__lastname_katakana = $("input#step1__lastname_katakana").val();
+    let value__birth_year = $("#user_profile_attributes_birth_year").val();
+    let value__birth_month = $("#user_profile_attributes_birth_month").val();
+    let value__birth_day = $("#user_profile_attributes_birth_day").val();
+
+    if(value__nickname == ""            || value__email == ""          || value__password == "" 
+      || value__firstname_kanji == ""   || value__lastname_kanji == "" || value__firstname_katakana == "" 
+      || value__lastname_katakana == "" || value__birth_year == "--"   || value__birth_month == "--" 
+      || value__birth_day == "--")
+    {
+      error = true;
+      window.alert("必須項目を入力してください");
+    }
+
+    else if(!value__nickname.match(/[^\s\t]/)         || !value__email.match(/[^\s\t]/)
+           || !value__password.match(/[^\s\t]/)       || !value__firstname_kanji.match(/[^\s\t]/) 
+           || !value__lastname_kanji.match(/[^\s\t]/) || !value__firstname_katakana.match(/[^\s\t]/) 
+           || !value__lastname_katakana.match(/[^\s\t]/))
+    {
+      error = true;
+      window.alert("空白を含まないでください");
+    }
+
+    else if (!value__email.match(/^([a-zA-Z0-9])+([a-zA-Z0-9\._-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9\._-]+)+$/))
+    {
+      error = true;
+      window.alert("emailを正しく入力してください");
+    }
+
+    else if(value__password.length <= 5)
+    {
+      debugger
+      window.alert("パスワードが短すぎます");
+    }
+
+    else{
+      $("#step1").hide();
+      $("#step3").hide();
+      $("#step2").show();
+      scrollTo(0,0);
+    }
   });
 
   $("#button__step2").on("click", function() {
@@ -16,4 +60,38 @@ $(function() {
     $("#step3").show();
     scrollTo(0,0);
   });
+
+  $("#new_user").on("submit", function(){
+    let error;
+    let value__firstname_kanji = $("input#step2__firstname_kanji").val();
+    let value__lastname_kanji = $("input#step2__lastname_kanji").val();
+    let value__firstname_katakana = $("input#step2__firstname_katakana").val();
+    let value__lastname_katakana = $("input#step2__lastname_katakana").val();
+    let value__post_number = $("input#step2__post_number").val();
+    let value__prefecture = $("#user_area_attributes_prefecture").val();
+    let value__city = $("input#step2__city").val();
+    let value__address_number = $("input#step2__address_number").val();
+
+    if(value__firstname_kanji == ""     || value__lastname_kanji == "" || value__firstname_katakana == ""
+      || value__lastname_katakana == "" || value__post_number == ""    || value__prefecture == "--"
+      || value__city == ""              || value__address_number== ""
+      )
+    {
+      error = true;
+      window.alert("必須項目を入力してください");
+      return false;
+    }
+    else if(!value__firstname_kanji.match(/[^\s\t]/)       || !value__lastname_kanji.match(/[^\s\t]/)
+            || !value__firstname_katakana.match(/[^\s\t]/) || !value__lastname_katakana.match(/[^\s\t]/)
+            || !value__post_number.match(/[^\s\t]/)        || !value__city.match(/[^\s\t]/)
+            || !value__address_number.match(/[^\s\t]/)
+            )
+    {
+      debugger
+      error = true;
+      window.alert("空白を含まないでください");
+      return false;
+    }
+  })
 })
+

--- a/app/assets/stylesheets/users/_information.scss
+++ b/app/assets/stylesheets/users/_information.scss
@@ -45,7 +45,9 @@
             border-radius: 5px;
             margin-top: 8px;
           }
-          #user_profile_attributes_birth_year,#user_profile_attributes_birth_month,#user_profile_attributes_birth_day{
+          #user_profile_attributes_birth_year,
+          #user_profile_attributes_birth_month,
+          #user_profile_attributes_birth_day{
             height: 48px;
             margin-top: 8px;
             width: 76px;

--- a/app/views/users/registrations/all_registration.html.haml
+++ b/app/views/users/registrations/all_registration.html.haml
@@ -13,25 +13,25 @@
                   ニックネーム
                 %span.input_content__form__box__necessary
                   必須
-                = f.text_field :nickname, {class: "form__input",placeholder: "例) メルカリ太郎"}
+                = f.text_field :nickname, {class: "form__input",id: "step1__nickname", placeholder: "例) メルカリ太郎"}
               .input_content__form__box
                 %label.input_content__form__box__detail
                   メールアドレス
                 %span.input_content__form__box__necessary
                   必須
-                = f.text_field :email, {class: "form__input", placeholder: "PC・携帯どちらでも可"}
+                = f.text_field :email, {class: "form__input",id: "step1__email", placeholder: "PC・携帯どちらでも可"}
               .input_content__form__box
                 %label.input_content__form__box__detail
                   パスワード
                 %span.input_content__form__box__necessary
                   必須
-                = f.text_field :password, {class: "form__input", placeholder: "6文字以上"}
+                = f.text_field :password, {class: "form__input",id: "step1__password", placeholder: "6文字以上"}
               .input_content__form__box
                 %label.input_content__form__box__detail
                   パスワード（確認）
                 %span.input_content__form__box__necessary
                   必須
-                = f.text_field :password, {class: "form__input", placeholder: "6文字以上"}
+                = f.text_field :password, {class: "form__input",id: "step1__password", placeholder: "6文字以上"}
               .input_content__form__box
                 %h3
                   本人確認
@@ -43,25 +43,25 @@
                     姓（全角）
                   %span.input_content__form__box__necessary
                     必須
-                  = pro.text_field :firstname_kanji, {class: "form__input", placeholder: "例）山田"}
+                  = pro.text_field :firstname_kanji, {class: "form__input",id: "step1__firstname_kanji", placeholder: "例）山田"}
                 .input_content__form__box
                   %label.input_content__form__box__detail
                     名（全角）
                   %span.input_content__form__box__necessary
                     必須
-                  = pro.text_field :lastname_kanji, {class: "form__input", placeholder: "例）彩"}
+                  = pro.text_field :lastname_kanji, {class: "form__input",id: "step1__lastname_kanji", placeholder: "例）彩"}
                 .input_content__form__box
                   %label.input_content__form__box__detail
                     姓カナ（全角）
                   %span.input_content__form__box__necessary
                     必須
-                  = pro.text_field :firstname_katakana, {class: "form__input", placeholder: "例）ヤマダ"}
+                  = pro.text_field :firstname_katakana, {class: "form__input",id: "step1__firstname_katakana", placeholder: "例）ヤマダ"}
                 .input_content__form__box
                   %label.input_content__form__box__detail
                     名カナ（全角）
                   %span.input_content__form__box__necessary
                     必須
-                  = pro.text_field :lastname_katakana, {class: "form__input", placeholder: "例）アヤ"}
+                  = pro.text_field :lastname_katakana, {class: "form__input",id: "step1__lastname_katakana", placeholder: "例）アヤ"}
                 .input_content__form__box
                   .box__birthday
                     %label.input_content__form__box__detail
@@ -122,23 +122,23 @@
                       お名前  
                     %span.address-form-require
                       必須
-                    = pro.text_field :firstname_kanji, class: 'address-registration-form', placeholder: '例）山田'  
-                    = pro.text_field :lastname_kanji, class: 'address-registration-form', placeholder: '例）彩' 
+                    = pro.text_field :firstname_kanji, class: 'address-registration-form',id: "step2__firstname_kanji", placeholder: '例）山田'  
+                    = pro.text_field :lastname_kanji, class: 'address-registration-form',id: "step2__lastname_kanji", placeholder: '例）彩' 
 
                   .new-registration-address_form__group--kananame
                     %label.address-kananame
                       お名前カナ  
                     %span.address-form-require
                       必須
-                    = pro.text_field :firstname_katakana, class: 'address-registration-form', placeholder: '例）ヤマダ'  
-                    = pro.text_field :firstname_katakana, class: 'address-registration-form', placeholder: '例）アヤ' 
+                    = pro.text_field :firstname_katakana, class: 'address-registration-form',id: "step2__firstname_katakana", placeholder: '例）ヤマダ'  
+                    = pro.text_field :lastname_katakana, class: 'address-registration-form',id: "step2__lastname_katakana", placeholder: '例）アヤ' 
                 
                   .new-registration-address_form__group--post-num
                     %label.address-post-num
                       郵便番号  
                     %span.address-form-require
                       必須
-                    = area.text_field :post_number, class: 'address-registration-form', placeholder: '例）123-4567'  
+                    = area.text_field :post_number, class: 'address-registration-form',id: "step2__post_number", placeholder: '例）123-4567'  
                     .new-registration-address_form__group--prefecture
                       %label.address-prefecture
                         都道府県 
@@ -154,14 +154,14 @@
                       市区町村
                     %span.address-form-require
                       必須
-                    = area.text_field :city, class: 'address-registration-form', placeholder: '例）横浜市緑区' 
+                    = area.text_field :city, class: 'address-registration-form',id: "step2__city", placeholder: '例）横浜市緑区' 
 
                   .new-registration-address_form__group--block-num
                     %label.address-block-num
                       番地
                     %span.address-form-require
                       必須
-                    = area.text_field :address_number, class: 'address-registration-form', placeholder: '例）青山1−1−1' 
+                    = area.text_field :address_number, class: 'address-registration-form',id: "step2__address_number", placeholder: '例）青山1−1−1' 
 
                   .new-registration-address_form__group--building
                     %label.address-building
@@ -177,5 +177,5 @@
                       任意
                     = pro.text_field :phone_number, class: 'address-registration-form', placeholder: '例）09012345678' 
                   
-                = f.submit "次へ進む", {class:"form-button"} 
+                = f.submit "次へ進む", {class:"form-button",id:"step2__button"} 
       = render "shared/details_footer"


### PR DESCRIPTION
# what
- 必須のフォームが何も入力されていない、スペースだけ入力されている場合エラーを表示
- パスワードが５文字以下の場合エラーを表示
- メールアドレスが正しく表示されていない場合エラーを表示
- フォームにidをそれぞれ追加

# why 
- バリデーションをかけるため
- deviseのデフォルトのバリデーションのエラー表示するため
- フォームそれぞれにバリデーションをかけるため

# 未完了のタスク
- テスト