### PR TITLE
[WIP]facebook, google認証機能作成(未完了タスクあり)

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,31 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+
+  def facebook
+    callback_for(:facebook)
+  end
+  
+  def google_oauth2
+    callback_for(:google)
+  end
+
+  # common callback method
+  def callback_for(provider)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
+      set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
+    else
+      session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")
+      redirect_to new_user_registration_url
+    end
+  end
+
+  def failure
+    redirect_to root_path
+  end
+
   # You should configure your model like this:
   # devise :omniauthable, omniauth_providers: [:twitter]
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -60,7 +60,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       sign_in(@user)
       redirect_to root_path
     else
-      render "users/registrations/information"
+      render "users/registrations/signup"
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,20 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  # :confirmable, :lockable, :timeoutable, :trackable
   has_one :profile
   has_many :like
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, 
+         :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
+
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.nickname = auth.info.name
+      user.email = auth.info.email
+      user.password = Devise.friendly_token[0,20]
+    end
+  end
 
   has_many :products
   has_many :likes, dependent: :destroy

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -9,14 +9,14 @@
               アカウントをお持ちでない方はこちら
             = link_to '新規会員登録', signup_path
           .login-box__google-facebook
-            %button.button__facebook
-              = icon 'fab', 'facebook-square', id: 'icon__facebook'
-              Facebookでログイン
-              = link_to '', ""
-            %button.button__google
-              = icon 'fab', 'google', id: 'icon__google'
-              Googleでログイン
-              = link_to '', ""
+            = link_to user_facebook_omniauth_authorize_path do
+              %button.button__facebook
+                = icon 'fab', 'facebook-square', id: 'icon__facebook'
+                Facebookでログイン
+            = link_to user_google_oauth2_omniauth_authorize_path do
+              %button.button__google
+                = icon 'fab', 'google', id: 'icon__google'
+                Googleでログイン
           = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
             .login-box__form
               = f.text_field :email, {class: "form-address",placeholder: "メールアドレス"}

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,6 +3,8 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], scope: 'email', redirect_uri: "http://localhost:3000/users/auth/google_oauth2/callback"
+  config.omniauth :facebook, ENV['FACEBOOK_CLIENT_ID'], ENV['FACEBOOK_CLIENT_SECRET'], scope: 'email', info_fields: 'email', callback_url: "http://localhost:3000/users/auth/facebook/callback"
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
@@ -296,4 +298,5 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   devise_scope :user do
     get 'login', to: 'devise/sessions#new'
     get 'signup', to: 'users/sessions#signup'

--- a/db/migrate/20190629045634_devise_create_users.rb
+++ b/db/migrate/20190629045634_devise_create_users.rb
@@ -4,7 +4,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
       ## Database authenticatable
-      t.string :nickname, null: false
+      t.string :nickname, null: false, default: ""
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
 

--- a/db/migrate/20190711042932_add_omniauth_to_users.rb
+++ b/db/migrate/20190711042932_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_06_065633) do
+ActiveRecord::Schema.define(version: 2019_07_11_042932) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
@@ -123,7 +123,7 @@ ActiveRecord::Schema.define(version: 2019_07_06_065633) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "nickname", null: false
+    t.string "nickname", default: "", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -131,6 +131,8 @@ ActiveRecord::Schema.define(version: 2019_07_06_065633) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# what
- user.rbでSNS側から送られてきた値を取得して変数に代入
- コールバック用にコントローラのアクションを作成
- コールバックした際に、モデルで指定した変数が入ったインスタンスを作成し、サインイン状態にする
- bash/profileに記載した環境変数を設定
- コールバック用にルーティングを設定
- providerカラムとuidカラムをuserモデルに追加
- ログイン画面のボタンにそれぞれpathを指定
- 登録に失敗した際のrender先を変更
- userテーブルのnicknameカラムにdefault: "" を追加

# why
- SNSのデータを取得して保存し、ログイン状態にさせるため

# 未完了タスク
- 本家メルカリだと、登録機能とログイン機能が分かれているが、
今回の実装では一緒くたになっている（DBにデータがあればログインし、なければ勝手に作成されてログイン状態になってしまう）
- emailアドレスがすでにあると登録ができない仕様になっている