### PR TITLE
[WIP]コントローラ内の、ユーザーの新規登録後の画面遷移方法を変更

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -15,7 +15,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.from_omniauth(request.env["omniauth.auth"])
     if @user.present?
       sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
-      set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
     else
       session["devise.omniauth_data"] = request.env["omniauth.auth"]
       redirect_to signup_all_path

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -59,17 +59,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
       @user = User.create(user_params)
     if @user.save
       sign_in(@user)
-      render "users/registrations/payment"
+      redirect_to signup_payment_path
     else
       render "users/signup"
     end
   end
 
-  def destroy
-    super
-    session[:keep_signed_out] = true
-  end
-  
   private
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])


### PR DESCRIPTION
# what
- ユーザーの新規登録後、クレジット登録画面に飛ばす方法をrenderからredirect_toに変更
- フラッシュメッセージを削除
- 不要なメソッドを削除
# why
- renderさせてもURLが切り替わらないため